### PR TITLE
Make complex room operations atomic

### DIFF
--- a/app/src/androidTest/kotlin/de/entikore/composedex/data/local/GenerationLocalDataSourceTest.kt
+++ b/app/src/androidTest/kotlin/de/entikore/composedex/data/local/GenerationLocalDataSourceTest.kt
@@ -30,21 +30,17 @@ import de.entikore.composedex.data.local.converter.TypesConverter
 import de.entikore.composedex.data.local.datasource.GenerationLocalDataSource
 import de.entikore.composedex.data.local.datasource.PokemonLocalDataSource
 import de.entikore.composedex.data.local.entity.generation.GenerationEntity
-import de.entikore.composedex.data.local.entity.pokemon.relation.PokemonWithSpeciesTypesAndVarieties
 import de.entikore.composedex.data.remote.model.generation.toEntity
 import de.entikore.composedex.data.remote.model.toEntity
 import de.entikore.sharedtestcode.GEN_II_FILE
 import de.entikore.sharedtestcode.GEN_I_FILE
 import de.entikore.sharedtestcode.GEN_VI_FILE
-import de.entikore.sharedtestcode.POKEMON_GLOOM_NAME
 import de.entikore.sharedtestcode.POKEMON_ODDISH_NAME
-import de.entikore.sharedtestcode.POKEMON_VILEPLUME_NAME
 import de.entikore.sharedtestcode.TestModelFactory.Companion.getGenerationListRemote
 import de.entikore.sharedtestcode.TestModelFactory.Companion.getGenerationRemote
 import de.entikore.sharedtestcode.TestModelFactory.Companion.getPokemonInfoRemote
 import de.entikore.sharedtestcode.TestModelFactory.Companion.getTestModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -75,15 +71,11 @@ class GenerationLocalDataSourceTest: LocalDataSourceTest() {
             .addTypeConverter(TypesConverter(moshi))
             .build()
         pokemonLocalDataSource = PokemonLocalDataSource(
-            pokemonDao = database.pokemonDao(),
-            speciesDao = database.speciesDao(),
-            varietyDao = database.varietyDao(),
-            typeDao = database.typeDao(),
+            database = database,
             dispatcher = mainCoroutineRule.getDispatcher()
         )
         localDataSource = GenerationLocalDataSource(
-            pokemonLocalDataSource = pokemonLocalDataSource,
-            generationDao = database.generationDao(),
+            database = database,
             dispatcher = mainCoroutineRule.getDispatcher()
         )
     }

--- a/app/src/androidTest/kotlin/de/entikore/composedex/data/local/PokemonLocalDataSourceTest.kt
+++ b/app/src/androidTest/kotlin/de/entikore/composedex/data/local/PokemonLocalDataSourceTest.kt
@@ -64,10 +64,7 @@ class PokemonLocalDataSourceTest: LocalDataSourceTest() {
             .addTypeConverter(TypesConverter(moshi))
             .build()
         localDataSource = PokemonLocalDataSource(
-            pokemonDao = database.pokemonDao(),
-            speciesDao = database.speciesDao(),
-            varietyDao = database.varietyDao(),
-            typeDao = database.typeDao(),
+            database = database,
             dispatcher = mainCoroutineRule.getDispatcher()
         )
 

--- a/app/src/androidTest/kotlin/de/entikore/composedex/data/local/TypeLocalDataSourceTest.kt
+++ b/app/src/androidTest/kotlin/de/entikore/composedex/data/local/TypeLocalDataSourceTest.kt
@@ -72,15 +72,11 @@ class TypeLocalDataSourceTest: LocalDataSourceTest() {
             .addTypeConverter(TypesConverter(moshi))
             .build()
         pokemonLocalDataSource = PokemonLocalDataSource(
-            pokemonDao = database.pokemonDao(),
-            speciesDao = database.speciesDao(),
-            varietyDao = database.varietyDao(),
-            typeDao = database.typeDao(),
+            database = database,
             dispatcher = mainCoroutineRule.getDispatcher()
         )
         localDataSource = TypeLocalDataSource(
-            pokemonLocalDataSource = pokemonLocalDataSource,
-            typeDao = database.typeDao(),
+            database = database,
             dispatcher = mainCoroutineRule.getDispatcher()
         )
     }

--- a/app/src/main/kotlin/de/entikore/composedex/data/local/ComposeDexDatabase.kt
+++ b/app/src/main/kotlin/de/entikore/composedex/data/local/ComposeDexDatabase.kt
@@ -17,6 +17,7 @@ package de.entikore.composedex.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.Transaction
 import androidx.room.TypeConverters
 import de.entikore.composedex.data.local.converter.ChainConverter
 import de.entikore.composedex.data.local.converter.StatsConverter
@@ -76,6 +77,44 @@ abstract class ComposeDexDatabase : RoomDatabase(), LocalStorage {
 
     override fun clearData() {
         this.clearAllTables()
+    }
+
+    @Transaction
+    suspend inline fun insertPokemonWithSpeciesTypesAndVarieties(
+        pokemon: PokemonEntity,
+        species: SpeciesEntity,
+        types: List<TypeEntity>,
+        varieties: List<VarietyEntity>
+    ) {
+        varieties.forEach { variety ->
+            varietyDao().insert(variety)
+            pokemonDao().insertVarietyCrossRef(
+                PokemonVarietyCrossRef(
+                    pokemon.pokemonId,
+                    variety.varietyName
+                )
+            )
+        }
+
+        types.forEach { type ->
+            typeDao().insert(type)
+            pokemonDao().insertTypeCrossRef(
+                PokemonTypeCrossRef(
+                    pokemon.pokemonId,
+                    type.typeId
+                )
+            )
+        }
+
+        speciesDao().insert(species)
+        pokemonDao().insertSpeciesCrossRef(
+            PokemonSpeciesCrossRef(
+                pokemon.pokemonId,
+                species.speciesId
+            )
+        )
+
+        pokemonDao().insert(pokemon)
     }
 
     companion object {

--- a/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/FavouriteLocalDataSource.kt
+++ b/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/FavouriteLocalDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Entikore
+ * Copyright 2025 Entikore
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ class FavouriteLocalDataSource(
 ) {
     suspend fun updateIsFavourite(pokemonId: Int, isFavourite: Boolean) =
         withContext(dispatcher) {
-            return@withContext pokemonDao.updateFavourite(FavouriteUpdate(pokemonId, isFavourite))
+            pokemonDao.updateFavourite(FavouriteUpdate(pokemonId, isFavourite))
         }
 
     fun getAllFavourites(): Flow<List<PokemonWithSpeciesTypesAndVarieties>> =

--- a/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/GenerationLocalDataSource.kt
+++ b/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/GenerationLocalDataSource.kt
@@ -19,7 +19,6 @@ import de.entikore.composedex.data.local.ComposeDexDatabase
 import de.entikore.composedex.data.local.dao.GenerationDao
 import de.entikore.composedex.data.local.entity.generation.GenerationEntity
 import de.entikore.composedex.data.local.entity.generation.GenerationOverviewEntity
-import de.entikore.composedex.data.local.entity.generation.relation.GenerationPokemonCrossRef
 import de.entikore.composedex.data.local.entity.pokemon.relation.PokemonWithSpeciesTypesAndVarieties
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -44,23 +43,13 @@ class GenerationLocalDataSource(
     suspend fun insertPokemonForGeneration(
         generation: GenerationEntity,
         fullPokemon: PokemonWithSpeciesTypesAndVarieties
-    ) {
+    ) =
         withContext(dispatcher) {
-            insertGeneration(generation)
-            database.insertPokemonWithSpeciesTypesAndVarieties(
-                fullPokemon.pokemon,
-                fullPokemon.species,
-                fullPokemon.types,
-                fullPokemon.varieties
-            )
-            generationDao.insertPokemonCrossRef(
-                GenerationPokemonCrossRef(
-                    generation.generationId,
-                    fullPokemon.pokemon.pokemonId
-                )
+            database.insertPokemonAndAssociateWithGeneration(
+                generation,
+                fullPokemon
             )
         }
-    }
 
     fun getGenerationOverview(): Flow<GenerationOverviewEntity?> = generationDao.getOverview()
 

--- a/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/TypeLocalDataSource.kt
+++ b/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/TypeLocalDataSource.kt
@@ -20,7 +20,6 @@ import de.entikore.composedex.data.local.dao.TypeDao
 import de.entikore.composedex.data.local.entity.pokemon.relation.PokemonWithSpeciesTypesAndVarieties
 import de.entikore.composedex.data.local.entity.type.TypeEntity
 import de.entikore.composedex.data.local.entity.type.TypeOverviewEntity
-import de.entikore.composedex.data.local.entity.type.relation.TypePokemonCrossRef
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -44,22 +43,13 @@ class TypeLocalDataSource(
     suspend fun insertPokemonForType(
         type: TypeEntity,
         fullPokemon: PokemonWithSpeciesTypesAndVarieties
-    ) {
+    ) =
         withContext(dispatcher) {
-            database.insertPokemonWithSpeciesTypesAndVarieties(
-                fullPokemon.pokemon,
-                fullPokemon.species,
-                fullPokemon.types,
-                fullPokemon.varieties,
-            )
-            typeDao.insertPokemonCrossRef(
-                TypePokemonCrossRef(
-                    type.typeId,
-                    fullPokemon.pokemon.pokemonId
-                )
+            database.insertPokemonAndAssociateWithType(
+                type.typeId,
+                fullPokemon
             )
         }
-    }
 
     fun getTypeOverview(): Flow<TypeOverviewEntity?> = typeDao.getOverview()
 

--- a/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/TypeLocalDataSource.kt
+++ b/app/src/main/kotlin/de/entikore/composedex/data/local/datasource/TypeLocalDataSource.kt
@@ -15,6 +15,7 @@
  */
 package de.entikore.composedex.data.local.datasource
 
+import de.entikore.composedex.data.local.ComposeDexDatabase
 import de.entikore.composedex.data.local.dao.TypeDao
 import de.entikore.composedex.data.local.entity.pokemon.relation.PokemonWithSpeciesTypesAndVarieties
 import de.entikore.composedex.data.local.entity.type.TypeEntity
@@ -29,10 +30,11 @@ import kotlinx.coroutines.withContext
  * Local data source for [TypeEntity] instances and their associated [PokemonWithSpeciesTypesAndVarieties].
  */
 class TypeLocalDataSource(
-    private val pokemonLocalDataSource: PokemonLocalDataSource,
-    private val typeDao: TypeDao,
+    private val database: ComposeDexDatabase,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
+    private val typeDao: TypeDao = database.typeDao()
+
     suspend fun insertTypeOverview(typeOverviewEntity: TypeOverviewEntity) =
         withContext(dispatcher) { typeDao.insertOverview(typeOverviewEntity) }
 
@@ -41,14 +43,19 @@ class TypeLocalDataSource(
 
     suspend fun insertPokemonForType(
         type: TypeEntity,
-        pokemon: PokemonWithSpeciesTypesAndVarieties
+        fullPokemon: PokemonWithSpeciesTypesAndVarieties
     ) {
         withContext(dispatcher) {
-            pokemonLocalDataSource.insertPokemonWithSpeciesTypesAndVarieties(pokemon)
+            database.insertPokemonWithSpeciesTypesAndVarieties(
+                fullPokemon.pokemon,
+                fullPokemon.species,
+                fullPokemon.types,
+                fullPokemon.varieties,
+            )
             typeDao.insertPokemonCrossRef(
                 TypePokemonCrossRef(
                     type.typeId,
-                    pokemon.pokemon.pokemonId
+                    fullPokemon.pokemon.pokemonId
                 )
             )
         }

--- a/app/src/main/kotlin/de/entikore/composedex/data/local/di/LocalModule.kt
+++ b/app/src/main/kotlin/de/entikore/composedex/data/local/di/LocalModule.kt
@@ -92,12 +92,9 @@ object LocalModule {
 
     @Provides
     fun providePokemonLocalDataSource(
-        pokemonDao: PokemonDao,
-        speciesDao: SpeciesDao,
-        varietyDao: VarietyDao,
-        typeDao: TypeDao
+        database: ComposeDexDatabase
     ): PokemonLocalDataSource =
-        PokemonLocalDataSource(pokemonDao, speciesDao, varietyDao, typeDao)
+        PokemonLocalDataSource(database)
 
     @Provides
     fun provideFavouriteLocalDataSource(pokemonDao: PokemonDao): FavouriteLocalDataSource =
@@ -107,14 +104,12 @@ object LocalModule {
 
     @Provides
     fun provideTypeLocalDataSource(
-        pokemonLocalDataSource: PokemonLocalDataSource,
-        typeDao: TypeDao
-    ): TypeLocalDataSource = TypeLocalDataSource(pokemonLocalDataSource, typeDao)
+        database: ComposeDexDatabase
+    ): TypeLocalDataSource = TypeLocalDataSource(database)
 
     @Provides
     fun provideGenerationLocalDataSource(
-        pokemonLocalDataSource: PokemonLocalDataSource,
-        generationDao: GenerationDao
+        database: ComposeDexDatabase
     ): GenerationLocalDataSource =
-        GenerationLocalDataSource(pokemonLocalDataSource, generationDao)
+        GenerationLocalDataSource(database)
 }


### PR DESCRIPTION
## Description

Make complex room operations including multiple DAOS atomic.

## Changes

Made the following operations from different LocalDataSources atomic:

- insertPokemonWithSpeciesTypesAndVarieties

- insertPokemonForGeneration

- insertPokemonForType

## Checklist

* [x] I have followed the coding style guidelines for this project.
* [x] I have added or updated relevant tests.
* [x] I have updated the documentation (if necessary).